### PR TITLE
Fixed a bug in apply single object actions and added get actions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
-## 0.2.o
+## 0.2.1
+- Fixed a bug in actions to apply a single object.
+- Added actions to get objects from the firewall.
+
+## 0.2.0
 Overhauled pack with breaking changes.
 
 Under the hood, the pack now uses [pandevice](https://github.com/PaloAltoNetworks/pandevice). Also added a number of new actions:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ The above objects may also be added and updated in bulk:
 - `bulk_apply_service_group`
 - `bulk_apply_security_rule`
 
+You may also retrieve these objects in a json serialized string (or as a raw python pandevice object)
+- `get_address_obejcts`
+- `get_address_groups`
+- `get_service_objects`
+- `get_service_groups`
+- `get_security_rules`
+
 #### IP/Tag registration
 You can dynamically register IP Addresses/tags to the device using the User-ID API.
 - `register_ip` and `bulk_register_ip`

--- a/actions/apply_single_object.py
+++ b/actions/apply_single_object.py
@@ -8,7 +8,7 @@ class ApplySingleObject(BaseAction):
     def run(self, class_string, device_group, firewall, **kwargs):
 
         device = self.get_panorama(firewall, device_group)
-        cls = self.get_pandevice_class(class_string)
+        cls = self.get_pandevice_class(class_string)['cls']
         obj = cls(**kwargs)
         device.add(obj)
         obj.apply()

--- a/actions/get_address_groups.yaml
+++ b/actions/get_address_groups.yaml
@@ -1,0 +1,27 @@
+---
+name: get_address_groups
+runner_type: python-script
+description: Get Address Group(s) from the device
+enabled: true
+entry_point: get_object.py
+parameters:
+  class_string:
+    type: string
+    default: AddressGroup
+    immutable: true
+  name:
+    type: string
+    description: Name of the object. When not passed, all objects of this type will be returned.
+    required: false
+  serialize:
+    type: boolean
+    description: When true, the return object(s) will be json serialized. When false, the action will return the raw pandevice python object(s).
+    default: true
+  device_group:
+    type: string
+    description: If interacting with a Panorama, the device group to add the object to. Will default to Shared if using Panorama
+    required: false
+  firewall:
+    type: string
+    description: Predefined firewall from pack config
+    required: false

--- a/actions/get_address_objects.yaml
+++ b/actions/get_address_objects.yaml
@@ -1,0 +1,27 @@
+---
+name: get_address_objects
+runner_type: python-script
+description: Get Address Object(s) from the device
+enabled: true
+entry_point: get_object.py
+parameters:
+  class_string:
+    type: string
+    default: AddressObject
+    immutable: true
+  name:
+    type: string
+    description: Name of the object. When not passed, all objects of this type will be returned.
+    required: false
+  serialize:
+    type: boolean
+    description: When true, the return object(s) will be json serialized. When false, the action will return the raw pandevice python object(s).
+    default: true
+  device_group:
+    type: string
+    description: If interacting with a Panorama, the device group to add the object to. Will default to Shared if using Panorama
+    required: false
+  firewall:
+    type: string
+    description: Predefined firewall from pack config
+    required: false

--- a/actions/get_object.py
+++ b/actions/get_object.py
@@ -1,0 +1,37 @@
+import json
+
+from lib.actions import BaseAction
+
+
+class GetObject(BaseAction):
+    """
+    Get object(s) from a device. If serialize is true, convert the object(s) to dicts and then to json
+    """
+    def run(self, class_string, name, serialize, device_group, firewall, **kwargs):
+
+        device = self.get_panorama(firewall, device_group)
+        cls = self.get_pandevice_class(class_string)['cls']
+        keys = self.get_pandevice_class(class_string)['valid_keys']
+        cls.refreshall(device)
+
+        if name:
+            obj = device.find(name, cls)
+        else:
+            obj = device.findall(cls)
+
+        if serialize:
+            if isinstance(obj, list):
+                data = []
+                for o in obj:
+                    serialized_obj = {}
+                    for key in keys:
+                        serialized_obj[key] = getattr(o, key)
+                    data.append(serialized_obj)
+            else:
+                data = {}
+                for key in keys:
+                    data[key] = getattr(obj, key)
+
+            return json.dumps(data)
+        else:
+            return obj

--- a/actions/get_object.py
+++ b/actions/get_object.py
@@ -5,7 +5,8 @@ from lib.actions import BaseAction
 
 class GetObject(BaseAction):
     """
-    Get object(s) from a device. If serialize is true, convert the object(s) to dicts and then to json
+    Get object(s) from a device. If serialize is true, convert the object(s) to
+    dicts and then to json
     """
     def run(self, class_string, name, serialize, device_group, firewall, **kwargs):
 

--- a/actions/get_security_rules.yaml
+++ b/actions/get_security_rules.yaml
@@ -1,0 +1,27 @@
+---
+name: get_security_rules
+runner_type: python-script
+description: Get Security Rule(s) from the device
+enabled: true
+entry_point: get_object.py
+parameters:
+  class_string:
+    type: string
+    default: SecurityRule
+    immutable: true
+  name:
+    type: string
+    description: Name of the object. When not passed, all objects of this type will be returned.
+    required: false
+  serialize:
+    type: boolean
+    description: When true, the return object(s) will be json serialized. When false, the action will return the raw pandevice python object(s).
+    default: true
+  device_group:
+    type: string
+    description: If interacting with a Panorama, the device group to add the object to. Will default to Shared if using Panorama
+    required: false
+  firewall:
+    type: string
+    description: Predefined firewall from pack config
+    required: false

--- a/actions/get_service_groups.yaml
+++ b/actions/get_service_groups.yaml
@@ -1,0 +1,27 @@
+---
+name: get_service_groups
+runner_type: python-script
+description: Get Service Group(s) from the device
+enabled: true
+entry_point: get_object.py
+parameters:
+  class_string:
+    type: string
+    default: ServiceGroup
+    immutable: true
+  name:
+    type: string
+    description: Name of the object. When not passed, all objects of this type will be returned.
+    required: false
+  serialize:
+    type: boolean
+    description: When true, the return object(s) will be json serialized. When false, the action will return the raw pandevice python object(s).
+    default: true
+  device_group:
+    type: string
+    description: If interacting with a Panorama, the device group to add the object to. Will default to Shared if using Panorama
+    required: false
+  firewall:
+    type: string
+    description: Predefined firewall from pack config
+    required: false

--- a/actions/get_service_objects.yaml
+++ b/actions/get_service_objects.yaml
@@ -1,0 +1,27 @@
+---
+name: get_service_objects
+runner_type: python-script
+description: Get Service Object(s) from the device
+enabled: true
+entry_point: get_object.py
+parameters:
+  class_string:
+    type: string
+    default: ServiceObject
+    immutable: true
+  name:
+    type: string
+    description: Name of the object. When not passed, all objects of this type will be returned.
+    required: false
+  serialize:
+    type: boolean
+    description: When true, the return object(s) will be json serialized. When false, the action will return the raw pandevice python object(s).
+    default: true
+  device_group:
+    type: string
+    description: If interacting with a Panorama, the device group to add the object to. Will default to Shared if using Panorama
+    required: false
+  firewall:
+    type: string
+    description: Predefined firewall from pack config
+    required: false

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description: Interact with Palo Alto firewalls
 keywords:
     - firewalls
     - threats
-version: 0.2.0
+version: 0.2.1
 author: Irek Romaniuk, John Anderson
 email: irek.romaniuk@gmail.com


### PR DESCRIPTION
## 0.2.1
- Fixed a bug in actions to apply a single object.
- Added actions to get objects from the firewall.

You may also retrieve these objects in a json serialized string (or as a raw python pandevice object)
- `get_address_obejcts`
- `get_address_groups`
- `get_service_objects`
- `get_service_groups`
- `get_security_rules`